### PR TITLE
Issue 53

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.8.RELEASE</version>
+		<version>2.1.9.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -45,17 +45,17 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
-			<version>2.0.8</version>
+			<version>2.0.17</version>
 		</dependency>
 		<dependency>
 			<groupId>io.searchbox</groupId>
 			<artifactId>jest</artifactId>
-			<version>5.3.3</version>
+			<version>6.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>21.0</version>
+			<version>28.1-jre</version>
 		</dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.192</version>
+			<version>1.4.199</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>3.0.7</version>
+			<version>4.1.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -142,7 +142,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.12</version>
+				<version>3.0.0</version>
 				<executions>
 					<!-- Other executions are omitted -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+            		<groupId>io.rest-assured</groupId>
+		    	<artifactId>json-path</artifactId>
+		    	<version>4.1.2</version>
+		    	<scope>test</scope>
+        	</dependency>
 		<!--
 			According to the official documentation this dependency is never included in production builds.
 			See https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html#using-boot-devtools

--- a/src/main/java/de/keybird/beagle/SecurityConfiguration.java
+++ b/src/main/java/de/keybird/beagle/SecurityConfiguration.java
@@ -22,13 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import de.keybird.beagle.security.CustomUserDetailsService;

--- a/src/main/java/de/keybird/beagle/SecurityConfiguration.java
+++ b/src/main/java/de/keybird/beagle/SecurityConfiguration.java
@@ -19,7 +19,6 @@
 package de.keybird.beagle;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.Http401AuthenticationEntryPoint;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,7 +34,6 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import de.keybird.beagle.security.CustomUserDetailsService;
 
 @Configuration
-@Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
 class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
@@ -79,6 +77,6 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .headers().frameOptions().sameOrigin()
         // Set a custom "WWW-Authenticate"-Header to prevent the browser to show the Basic Auth dialogue
         .and()
-            .exceptionHandling().authenticationEntryPoint(new Http401AuthenticationEntryPoint("BasicAngular"));
+            .exceptionHandling().authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
     }
 }

--- a/src/main/java/de/keybird/beagle/jobs/execution/IndexJobExecution.java
+++ b/src/main/java/de/keybird/beagle/jobs/execution/IndexJobExecution.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -94,9 +95,9 @@ public class IndexJobExecution implements JobExecution<IndexJob> {
             for (List<Long> partition : partitions) {
                 // Initialize all pages of transaction
                 List<Page> pagesToImport = transactionTemplate.execute(status -> partition.stream().map(id -> {
-                    final Page page = pageRepository.findOne(id);
-                    page.getPayload();
-                    return page;
+                    final Optional<Page> page = pageRepository.findById(id);
+                    page.get().getPayload();
+                    return page.get();
                 }).collect(Collectors.toList()));
 
                 // Perform Indexing
@@ -104,7 +105,7 @@ public class IndexJobExecution implements JobExecution<IndexJob> {
 
                 // Flush the data
                 transactionTemplate.execute(status -> {
-                    pageRepository.save(pagesToImport);
+                    pageRepository.saveAll(pagesToImport);
                     return null;
                 });
 

--- a/src/main/java/de/keybird/beagle/rest/ImportRestController.java
+++ b/src/main/java/de/keybird/beagle/rest/ImportRestController.java
@@ -19,6 +19,7 @@
 package de.keybird.beagle.rest;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -89,15 +90,15 @@ public class ImportRestController {
 
     @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
     public ResponseEntity<Void> deleteDocument(@PathVariable("id") long documentId) {
-        final Document document = documentRepository.findOne(documentId);
+        final Optional<Document> document = documentRepository.findById(documentId);
         if (document == null) {
             return ResponseEntity.notFound().build();
         }
-        // TODO MVR this is ugly, but for now we kee it
+        // TODO MVR this is ugly, but for now we keep it
         if (jobExecutionManager.hasRunningJobs()) {
             throw new IllegalStateException("Cannot delete documents while jobs are running");
         }
-        documentRepository.delete(document);
+        documentRepository.delete(document.get());
         return ResponseUtils.noContent();
     }
 }

--- a/src/main/java/de/keybird/beagle/rest/PageRestController.java
+++ b/src/main/java/de/keybird/beagle/rest/PageRestController.java
@@ -21,6 +21,7 @@ package de.keybird.beagle.rest;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -86,21 +87,21 @@ public class PageRestController {
     @RequestMapping(value = "{id}", method = RequestMethod.GET)
     @Transactional
     public ResponseEntity getPayload(@PathVariable("id") long pageId) {
-        final Page page = pageRepository.findOne(pageId);
+        final Optional<Page> page = pageRepository.findById(pageId);
         if (page == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_PDF).body(page.getPayload());
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_PDF).body(page.get().getPayload());
     }
 
     @RequestMapping(value = "{id}/thumbnail", method = RequestMethod.GET)
     @Transactional
     public ResponseEntity getThumbnail(@PathVariable("id") long pageId) {
-        final Page page = pageRepository.findOne(pageId);
+        final Optional<Page> page = pageRepository.findById(pageId);
         if (page == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG).body(page.getThumbnail());
+        return ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG).body(page.get().getThumbnail());
     }
 
     // TODO MVR we should not propagate the exception to the user,
@@ -138,9 +139,9 @@ public class PageRestController {
                 if (jsonElement != null) {
                     final long internalId = jsonElement.getAsLong();
                     // TODO MVR We should identify a page by its checksum instead
-                    final Page page = pageRepository.findOne(internalId);
+                    final Optional<Page> page = pageRepository.findById(internalId);
                     if (page != null) {
-                        pages.add(new PageDTO(page));
+                        pages.add(new PageDTO(page.get()));
                     }
                 }
             }


### PR DESCRIPTION
What was changed and Related Information:

1. pom.xml

org.springframework.boot: 1.5.8.RELEASE to 2.1.9.RELEASE
org.apache.pdfbox:pdfbox: 2.0.8 to 2.0.17
io.searchbox:jest:5.3.3 to 6.3.1
com.google.guava:guava:21.0 to 28.1-jre
com.h2database:h2:1.4.192 to 1.4.199
io.rest-assured:rest-assured:3.0.7 to 4.1.2
org.codehaus.mojo:build-helper-maven-plugin:1.12 to 3.0.0
Added json-path 4.1.2

2. SecurityConfiguration.java

Removed below annotation as it is no longer needed
@Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)

**Reference:**
SecurityProperties no longer defines the ACCESS_OVERRIDE_ORDER constant for the @Order annotation. However, Spring Boot no longer defines any security details if the application does, so we do not need the @Order annotation on the security @Configuration class and can be removed.
https://stackoverflow.com/questions/45529743/ordersecurityproperties-access-override-order-vs-managementserverproperties-a

3. ImportRestController.java
4. PageRestController.java
5. IndexJobExecution.java

Replaced findById in place of findOne as this is obsoleted in latest versions.

**Reference:** https://stackoverflow.com/questions/44101061/missing-crudrepositoryfindone-method
**Reference:** https://stackoverflow.com/questions/49241384/401-instead-of-403-with-spring-boot-2